### PR TITLE
Fix non root access

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ ADD shell.nix /
 # Clean up non-essential downloaded archives after provisioning a shell.
 RUN nix-shell /shell.nix --indirect --add-root /nix-shell-gc-root \
     && nix-collect-garbage
+RUN IN_NIX_SHELL=1 nix-instantiate \
+    --add-root /shell.drv --indirect /shell.nix \
+    && nix-collect-garbage
 ```
 
 New versions of this image are pushed to [DockerHub][dockerhub-image]

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -12,6 +12,9 @@ for i in range(1, len(sys.argv)):
     if sys.argv[i] == 'stack':
         args.append('$STACK_IN_NIX_EXTRA_ARGS')
 
-command = ["nix-shell", "/shell.drv", "--run"] + [' '.join(args)]
+drv_exist = os.access("/shell.drv", os.F_OK)
+shell_file = "/shell.drv" if drv_exist else "/shell.nix"
+
+command = ["nix-shell", shell_file, "--run"] + [' '.join(args)]
 
 call(command)

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -12,6 +12,6 @@ for i in range(1, len(sys.argv)):
     if sys.argv[i] == 'stack':
         args.append('$STACK_IN_NIX_EXTRA_ARGS')
 
-command = ["nix-shell", "/shell.nix", "--run"] + [' '.join(args)]
+command = ["nix-shell", "/shell.drv", "--run"] + [' '.join(args)]
 
 call(command)


### PR DESCRIPTION
Allows running stack in the container without being root (which is needed for using `stack --docker` with this image).

This also removes a possible impurity (if the shell file uses `builtins.fetchurl`), as the `shell.nix` file is only evaluated while building the image instead of every time a command is run.

Clients need to update their `Dockerfile` as described in the new `README` in order to profit from this